### PR TITLE
unity-cli@v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ unity-cli license-context
 
 #### Licensing Logs
 
-`licensing-logs`: Prints the Unity licensing logs.
+`licensing-logs`: Prints the path to the Unity Licensing Client log files.
 
 ```bash
 unity-cli licensing-logs
@@ -162,6 +162,7 @@ unity-cli hub-install
 `hub [options] <args...>`: Run Unity Hub command line arguments (passes args directly to the hub executable).
 
 - `--verbose`: Enable verbose output.
+- `--json`: Prints the last line of output as a json string, which contains the operation results.
 - `<args...>`: Arguments to pass directly to the Unity Hub executable.
 
 Lists available Unity Hub commands:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rage-against-the-pixel/unity-cli",
-      "version": "1.6.0",
+      "version": "1.6.2",
       "license": "MIT",
       "dependencies": {
         "@electron/asar": "^4.0.1",
@@ -2811,9 +2811,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.260",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.260.tgz",
-      "integrity": "sha512-ov8rBoOBhVawpzdre+Cmz4FB+y66Eqrk6Gwqd8NGxuhv99GQ8XqMAr351KEkOt7gukXWDg6gJWEMKgL2RLMPtA==",
+      "version": "1.5.262",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
+      "integrity": "sha512-NlAsMteRHek05jRUxUR0a5jpjYq9ykk6+kO0yRaMi5moe7u0fVIOeQ3Y30A8dIiWFBNUoQGi1ljb1i5VtS9WQQ==",
       "dev": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A command line utility for the Unity Game Engine.",
   "author": "RageAgainstThePixel",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -149,7 +149,7 @@ program.command('license-context')
     });
 
 program.command('licensing-logs')
-    .description('Print the path to the Unity Licensing Client log files.')
+    .description('Prints the path to the Unity Licensing Client log files.')
     .action(async () => {
         const client = new LicensingClient();
         process.stdout.write(`${client.logPath()}\n`);
@@ -224,6 +224,7 @@ program.command('hub-install')
 program.command('hub')
     .description('Run commands directly to the Unity Hub. (You need not to pass --headless or -- to this command).')
     .option('--verbose', 'Enable verbose logging.')
+    .option('--json', 'Prints the last line of output as a json string, which contains the operation results.')
     .allowUnknownOption(true)
     .argument('<args...>', 'Arguments to pass to the Unity Hub executable.')
     .action(async (args: string[], options) => {
@@ -234,7 +235,12 @@ program.command('hub')
         Logger.instance.debug(JSON.stringify({ args, options }));
 
         const unityHub = new UnityHub();
-        await unityHub.Exec(args, { silent: false, showCommand: Logger.instance.logLevel === LogLevel.DEBUG });
+        const output = await unityHub.Exec(args, { silent: false, showCommand: Logger.instance.logLevel === LogLevel.DEBUG });
+
+        if (options.json) {
+            process.stdout.write(`\n${JSON.stringify({ output })}\n`);
+        }
+
         process.exit(0);
     });
 


### PR DESCRIPTION
- add `--json` output for `hub` command to print the last line of output as a json string, which contains the operation results.
- updated docs
- bump deps