### PR TITLE
unity-cli@v1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rage-against-the-pixel/unity-cli",
-      "version": "1.6.9",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@electron/asar": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "description": "A command line utility for the Unity Game Engine.",
   "author": "RageAgainstThePixel",
   "license": "MIT",

--- a/src/license-client.ts
+++ b/src/license-client.ts
@@ -713,12 +713,12 @@ export class LicensingClient {
         }
         else {
             await this.exec([`--return-ulf`]);
-        }
 
-        const activeLicenses = await this.GetActiveEntitlements();
+            const activeLicenses = await this.GetActiveEntitlements();
 
-        if (activeLicenses.includes(licenseType)) {
-            throw new Error(`Failed to return license of type '${licenseType}'`);
+            if (activeLicenses.includes(licenseType)) {
+                throw new Error(`Failed to return license of type '${licenseType}'`);
+            }
         }
 
         this.logger.info(`Successfully returned license of type '${licenseType}'`);


### PR DESCRIPTION
- don't call entailment check when returning floating license