### PR TITLE
unity-cli@v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rage-against-the-pixel/unity-cli",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
         "@electron/asar": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rage-against-the-pixel/unity-cli",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A command line utility for the Unity Game Engine.",
   "author": "RageAgainstThePixel",
   "license": "MIT",

--- a/src/license-client.ts
+++ b/src/license-client.ts
@@ -638,11 +638,7 @@ export class LicensingClient {
      * @throws Error if deactivation fails.
      */
     public async Deactivate(licenseType: LicenseType, token?: string): Promise<void> {
-        const activeLicenses = await this.GetActiveEntitlements();
-
-        if (activeLicenses.includes(licenseType)) {
-            await this.returnLicense(licenseType, token);
-        }
+        await this.returnLicense(licenseType, token);
     }
 
     /**
@@ -712,9 +708,16 @@ export class LicensingClient {
             await this.exec([`--return-floating`, token]);
         }
         else {
-            await this.exec([`--return-ulf`]);
+            let activeLicenses = await this.GetActiveEntitlements();
 
-            const activeLicenses = await this.GetActiveEntitlements();
+            if (activeLicenses.includes(licenseType)) {
+                await this.exec([`--return-ulf`]);
+            } else {
+                this.logger.info(`No active license of type '${licenseType}' found`);
+                return;
+            }
+
+            activeLicenses = await this.GetActiveEntitlements();
 
             if (activeLicenses.includes(licenseType)) {
                 throw new Error(`Failed to return license of type '${licenseType}'`);


### PR DESCRIPTION
- when returning license, skip GetActiveEntitlements for floating licenses